### PR TITLE
fix for mix-up between wp_paginate and wp_paginate_comments

### DIFF
--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -412,6 +412,7 @@ if (class_exists('WPPaginate')) {
  */
 function wp_paginate($args = false) {
 	global $wp_paginate;
+	$wp_paginate->type = 'posts';
 	return $wp_paginate->paginate($args);
 }
 


### PR DESCRIPTION
If wp_paginate and wp_paginate_comments are called on the same page, wp_paginate will output wp_paginate_comments instead. This fixes the issue.
