### PR TITLE
Fixed problem with loading pages on https protocol

### DIFF
--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -86,7 +86,7 @@ if (!class_exists('WPPaginate')) {
 			load_plugin_textdomain($this->localizationDomain, false, "$name/I18n/");
 
 			//"Constants" setup
-			$this->pluginurl = WP_PLUGIN_URL . "/$name/";
+			$this->pluginurl = plugins_url($name)."/";
 			$this->pluginpath = WP_PLUGIN_DIR . "/$name/";
 
 			//Initialize the options


### PR DESCRIPTION
When connecting css files used WP_PLUGIN_URL constants, which
always starts with "http://". Constant is replaced by a function
call "plugins_url".
