### PR TITLE
Remove PHP4 support to resolve PHP Strict warning

### DIFF
--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -72,12 +72,7 @@ if (!class_exists('WPPaginate')) {
 		var $type = 'posts';
 
 		/**
-		 * PHP 4 Compatible Constructor
-		 */
-		function WPPaginate() {$this->__construct();}
-
-		/**
-		 * PHP 5 Constructor
+		 * Constructor
 		 */
 		function __construct() {
 			$name = dirname(plugin_basename(__FILE__));


### PR DESCRIPTION
Now that WordPress only officially supports 3.5+ and that requires PHP 5.2.4 or greater...
... we can resolve the PHP Strict error which is caused by PHP4 specific code.

```
URL: http://example.com/2008/06/10/post-format-test-gallery/dsc20050813_115856_52/
Referrer: http://example.com/
Error(E_STRICT): Redefining already defined constructor for class WPPaginate
Source: /var/sites/g/example.com/public_html/wp-content/plugins/wp-paginate/wp-paginate.php [82]

Trace:
#1 /var/sites/g/example.com/public_html/index.php:17 - require('/var/si...')
#2 /var/sites/g/example.com/public_html/wp-blog-header.php:12 - require_once('/var/si...')
#3 /var/sites/g/example.com/public_html/wp-load.php:29 - require_once('/var/si...')
#4 /var/sites/g/example.com/public_html/wp-config.php:163 - require_once('/var/si...')
#5 /var/sites/g/example.com/public_html/wp-settings.php:195 - include_once()
```
