### PR TITLE
Removed final closing PHP tag

### DIFF
--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -424,4 +424,3 @@ function wp_paginate_comments($args = false) {
  * The format of this plugin is based on the following plugin template:
  * http://pressography.com/plugins/wordpress-plugin-template/
  */
-?>


### PR DESCRIPTION
Resolve any question of white space output from plugin by removing closing PHP tag.
Using closing PHP tag is bad practice.
In addition it appears github's "editor" adds new lines to the end of files after edit, pull #4 may have introduced white space output. 
