### PR TITLE
We do not add the first li>span if title is empty

### DIFF
--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -130,7 +130,9 @@ if (!class_exists('WPPaginate')) {
 			$output = stripslashes($before);
 			if ($pages > 1) {
 				$output .= sprintf('<ol class="wp-paginate%s">', ($this->type === 'posts') ? '' : ' wp-paginate-comments');
-				$output .= sprintf('<li><span class="title">%s</span></li>', stripslashes($title));
+				if (strlen(stripslashes($title)) > 0) {
+					$output .= sprintf('<li><span class="title">%s</span></li>', stripslashes($title));
+				}
 				$ellipsis = "<li><span class='gap'>...</span></li>";
 
 				if ($page > 1 && !empty($previouspage)) {


### PR DESCRIPTION
We do not add the first li>span if in WP Admin we didn't specify any title for the pagination.
