### PR TITLE
V2.0.0

### DIFF
--- a/wp-paginate.css
+++ b/wp-paginate.css
@@ -1,8 +1,10 @@
 /*
  * WP-Paginate - WordPress Pagination Function
- * Revision: $Id: wp-paginate.css 943040 2014-07-03 18:30:39Z emartin24 $
- * Copyright (c) 2014 Eric Martin http://www.ericmmartin.com/projects/wp-paginate/
+ * Revision: $Id: wp-paginate.css 1044618 2014-12-14 23:43:29Z emartin24 $
+ * Copyright 2014 Studio Fuel (http://www.studiofuel.com)
  */
+ 
+ /* Legacy Styles */
 .wp-paginate {padding:0; margin:0;}
 .wp-paginate li {display:inline; list-style:none;}
 .wp-paginate a {background:#ddd; border:1px solid #ccc; color:#666; margin-right:4px; padding:4px 8px; text-align:center; text-decoration:none;}
@@ -23,3 +25,53 @@
 .wp-paginate-comments .current {}
 .wp-paginate-comments .page {}
 .wp-paginate-comments .prev, .wp-paginate-comments .next {}
+
+/* EX Styles */
+.wp-paginate-ex {
+    list-style: none;
+    clear: none;
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+.wp-paginate-ex li {
+    display: inline-block;
+    height: 20px;
+    margin: 0 0 0 10px;
+    }
+.wp-paginate-ex li a {
+    display: inline-block;
+    height: 20px;
+    background: none repeat scroll 0 0 #ddd !important;
+    border: 1px solid #ccc;
+    color: #666;
+    line-height: 20px;
+    text-decoration: none;
+    padding: 0 5px;
+}
+.wp-paginate-ex li a:hover { /* page links hover styling */ }
+.wp-paginate-ex li.active {
+    background: none repeat scroll 0 0 #5f87ae !important;
+    border: 1px solid #89adcf;
+    color: #fff;
+    line-height: 20px;
+    text-decoration: none;
+    padding: 0 5px;
+}
+.wp-paginate-ex li.disabled {
+    display: none;
+}
+.wp-paginate-ex .first::after,
+.wp-paginate-ex .jumpback::after {
+    display: block;
+    float: right;
+    content: ' \2026';
+    margin: 0 0 0 10px;
+}
+.wp-paginate-ex .last::before,
+.wp-paginate-ex .jumpfwd::before {
+    display: block;
+    float: left;
+    content: '\2026 ';
+    margin: 0 10px 0 0;
+}

--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -5,7 +5,7 @@ Plugin URI: http://www.studiofuel.com/wp-paginate/
 Description: A simple and flexible pagination plugin for WordPress posts and comments.
 Version: 2.0
 Author: Noah Cinquini, EX additions by Matthew Sigley
-Author URI: http://www.studiofuel.com
+Author URI: http://www.studiofuel.com, https://github.com/msigley
 */
 
 /*  Copyright 2014 Studio Fuel (http://www.studiofuel.com)

--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -44,7 +44,7 @@ if (!class_exists('WPPaginate')) {
 		/**
 		 * @var string The plugin version
 		 */
-		var $version = '1.3.1';
+		var $version = '2.0.0';
 
 		/**
 		 * @var string The options string name for this plugin

--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -224,7 +224,7 @@ if (!class_exists('WPPaginate')) {
 				'first' => '1',
 				'last' => '',
 				'show' => 1000,
-				'class' => sprintf('wp-paginate-ex-%s', ($this->type === 'posts') ? '' : ' wp-paginate-ex-comments'),
+				'class' => sprintf('wp-paginate-ex%s', ($this->type === 'posts') ? '' : ' wp-paginate-ex-comments'),
 				'classactive' => 'active',
 				'classdisabled' => 'disabled',
 				'classprevious' => 'previous',
@@ -312,7 +312,7 @@ if (!class_exists('WPPaginate')) {
 				$_[] = $after;
 			}
 			
-			echo join("\n", $_);
+			echo join('', $_);
 		}
 
 		/**

--- a/wp-paginate.php
+++ b/wp-paginate.php
@@ -224,7 +224,7 @@ if (!class_exists('WPPaginate')) {
 				'first' => '1',
 				'last' => '',
 				'show' => 1000,
-				'class' => sprintf('wp-paginate%s', ($this->type === 'posts') ? '' : ' wp-paginate-comments'),
+				'class' => sprintf('wp-paginate-ex-%s', ($this->type === 'posts') ? '' : ' wp-paginate-ex-comments'),
 				'classactive' => 'active',
 				'classdisabled' => 'disabled',
 				'classprevious' => 'previous',


### PR DESCRIPTION
Added wp_paginate_ex() and wp_paginate_ex_comments() functions that produce a more extensible pagination that is more mobile friendly and adds support for first, last, jump forward, and jump backward links.

The original pagination function was sourced and modified from the Shopp project:
https://github.com/ingenesis/shopp

I name spaced the new pagination functions with _ex suffixes to avoid breaking existing themes built on the original wp_paginate functions.
